### PR TITLE
Requirements version constraint bugfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "lxml>=4.3.3,<5",
         "more-itertools==7.0.0",
         "python-docx>=0.8.10",
-        "six>=1.12.0<2",
+        "six>=1.12.0,<2",
         "wincertstore==0.2",
     ],
     extras_require={':python_version=="2.6"': ["argparse"]},


### PR DESCRIPTION
Existing requirement `"six>=1.12.0<2"` yields
```
× python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      error in simplify-docx setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          six>=1.12.0<2
             ~~~~~~~~^
      [end of output]
```
This one character fix resolves it.